### PR TITLE
fixing check for variable existence

### DIFF
--- a/roboclaw_node/nodes/roboclaw_node.py
+++ b/roboclaw_node/nodes/roboclaw_node.py
@@ -228,7 +228,7 @@ class Node:
                 rospy.logwarn("ReadEncM2 OSError: %d", e.errno)
                 rospy.logdebug(e)
 
-            if (enc1 in locals()) & (enc2 in locals()):
+            if ('enc1' in vars()) and ('enc2' in vars()):
                 rospy.logdebug(" Encoders %d %d" % (enc1, enc2))
                 self.encodm.update_publish(enc1, enc2)
 


### PR DESCRIPTION
By trying to call enc1 and enc2 with them possibly not being defined it
can throw a NameError. In addition, when it is defined, this will always
evaluate to true unless the /value/ of enc1 and enc2 are strings that
are the names of variables. locals() returns a dictionary, where the
keys are the names of the variable as type string and the values are the
values of the variables. The search must be performed with a string
instead of by type. This also avoids the earlier mentioned error.