### PR TITLE
rotation angle is backward

### DIFF
--- a/roboclaw_node/nodes/roboclaw_node.py
+++ b/roboclaw_node/nodes/roboclaw_node.py
@@ -86,7 +86,7 @@ class EncoderOdom:
 
         br = tf.TransformBroadcaster()
         br.sendTransform((cur_x, cur_y, 0),
-                         tf.transformations.quaternion_from_euler(0, 0, cur_theta),
+                         tf.transformations.quaternion_from_euler(0, 0, -cur_theta),
                          current_time,
                          "base_link",
                          "odom")


### PR DESCRIPTION
`tf.TransformBroadcaster.sendTransform` takes in the transformation from
the child frame to the parent frame. In this case `base_link` (the robot's
frame) is the child and the parent is `odom`. To transform from the
robot's frame to the parent frame, the angle should be negative of the
robot's frame relative to the world.