### PR TITLE
Fix typo when reading ticks_per_meter parameter

### DIFF
--- a/roboclaw_node/nodes/roboclaw_node.py
+++ b/roboclaw_node/nodes/roboclaw_node.py
@@ -177,7 +177,7 @@ class Node:
         roboclaw.ResetEncoders(self.address)
 
         self.MAX_SPEED = float(rospy.get_param("~max_speed", "2.0"))
-        self.TICKS_PER_METER = float(rospy.get_param("~tick_per_meter", "4342.2"))
+        self.TICKS_PER_METER = float(rospy.get_param("~ticks_per_meter", "4342.2"))
         self.BASE_WIDTH = float(rospy.get_param("~base_width", "0.315"))
 
         self.encodm = EncoderOdom(self.TICKS_PER_METER, self.BASE_WIDTH)


### PR DESCRIPTION
SYMPTOM: self.TICKS_PER_METER is always at default value, regardless
of value in roboclaw.launch or any other parameter server.

CAUSE: A typo in call to rospy.get_param() means it is trying to
retrieve a value that does not exist, instead of the intended
parameter value.

FIX: Add missing 's' to properly retrieve 'ticks_per_meter' value