### PR TITLE
Fix to avoid TypeError with encoder count value of 'None'

### DIFF
--- a/roboclaw_node/nodes/roboclaw_node.py
+++ b/roboclaw_node/nodes/roboclaw_node.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from math import pi, cos, sin
+from numbers import Number
 
 import diagnostic_msgs
 import diagnostic_updater
@@ -228,7 +229,7 @@ class Node:
                 rospy.logwarn("ReadEncM2 OSError: %d", e.errno)
                 rospy.logdebug(e)
 
-            if ('enc1' in vars()) and ('enc2' in vars()):
+            if (isinstance(enc1,Number) and isinstance(enc2,Number)):
                 rospy.logdebug(" Encoders %d %d" % (enc1, enc2))
                 self.encodm.update_publish(enc1, enc2)
 


### PR DESCRIPTION
SYMPTOM: Unpredictable errors occurring at runtime
    File "roboclaw_node.py", line 232, in run
        rospy.logdebug(" Encoders %d %d" % (enc1, enc2))
    TypeError: %d format: a number is required, not NoneType

SEE: Issue #13 

CAUSE: Error when calling roboclaw.ReadEnc would result in encoder
values 'enc1' or 'enc2' to be None instead of a number. This triggers
TypeError as described above.

FIX: Do exactly what TypeError wants us to do: make sure both 'enc1' and
'enc2' are numbers before trying to format them as numbers for logging.
(Note this does not address root cause of ReadEnc failure, that will be
submitted as a separate fix.)

REFERENCE: Python number check courtesy of StackOverflow: https://stackoverflow.com/questions/3441358/what-is-the-most-pythonic-way-to-check-if-an-object-is-a-number