### PR TITLE
Fix left/right reversal in odometry update

### DIFF
--- a/roboclaw_node/nodes/roboclaw_node.py
+++ b/roboclaw_node/nodes/roboclaw_node.py
@@ -86,7 +86,7 @@ class EncoderOdom:
 
         br = tf.TransformBroadcaster()
         br.sendTransform((cur_x, cur_y, 0),
-                         tf.transformations.quaternion_from_euler(0, 0, -cur_theta),
+                         tf.transformations.quaternion_from_euler(0, 0, cur_theta),
                          current_time,
                          "base_link",
                          "odom")
@@ -230,7 +230,7 @@ class Node:
 
             if ('enc1' in vars()) and ('enc2' in vars()):
                 rospy.logdebug(" Encoders %d %d" % (enc1, enc2))
-                self.encodm.update_publish(enc1, enc2)
+                self.encodm.update_publish(enc2, enc1) # update_publish(enc_left, enc_right)
 
                 self.updater.update()
             r_time.sleep()


### PR DESCRIPTION
SYMPTOM: When robot turns right, /odom pose orientation turns left.
(And vice versa.) However, the odom->base_link transform is correct.

CAUSE: Encoder odometry entry point update_publish(enc_left,enc_right)
is invoked with update_publish(enc1, enc2). But this is backwards. As
per cmd_vel_callback, motor 1 is the right-hand side motor and motor 2
the left-hand side.

Why does the odom->base_link transform look OK? An earlier change
added a negative sign in front of the published transform angle. This
only masked the error without fixing the underlying cause, resulting in
reversed /odom data and leaving variables like self.last_enc_right
holding the wrong values.

FIX: Reverse the parameters when calling update_publish so they are
correct. And now that the underlying problem is addressed, the negative
sign must be removed from the angle when publishing transform.