### PR TITLE
Fix wrong param name

### DIFF
--- a/roboclaw_node/nodes/roboclaw_node.py
+++ b/roboclaw_node/nodes/roboclaw_node.py
@@ -177,7 +177,7 @@ class Node:
         roboclaw.ResetEncoders(self.address)
 
         self.MAX_SPEED = float(rospy.get_param("~max_speed", "2.0"))
-        self.TICKS_PER_METER = float(rospy.get_param("~tick_per_meter", "4342.2"))
+        self.TICKS_PER_METER = float(rospy.get_param("~ticks_per_meter", "4342.2"))
         self.BASE_WIDTH = float(rospy.get_param("~base_width", "0.315"))
 
         self.encodm = EncoderOdom(self.TICKS_PER_METER, self.BASE_WIDTH)


### PR DESCRIPTION
In the old version the node always used the default value. Now you can overwrite the value at the launch with roslaunch.